### PR TITLE
Infra chores.

### DIFF
--- a/aws_setup/config_c4.8xlarge.json
+++ b/aws_setup/config_c4.8xlarge.json
@@ -16,10 +16,10 @@
         {
           "DeviceName": "/dev/xvda",
           "Ebs": {
-            "DeleteOnTermination": false,
+            "DeleteOnTermination": true,
             "VolumeType": "io1",
-            "VolumeSize": 50,
-            "SnapshotId": "snap-32fb8628",
+            "VolumeSize": 100,
+            "SnapshotId": "snap-07a718cb535184f17",
             "Iops": 300
           }
         }
@@ -28,96 +28,6 @@
         {
           "DeviceIndex": 0,
           "SubnetId": "subnet-4fd86439",
-          "DeleteOnTermination": true,
-          "Groups": [
-            "sg-38353646",
-            "sg-c43437ba"
-          ],
-          "AssociatePublicIpAddress": true
-        }
-      ]
-    },
-    {
-      "ImageId": "ami-27152c5c",
-      "InstanceType": "c4.8xlarge",
-      "KeyName": "aws01",
-      "SpotPrice": "0.9",
-      "BlockDeviceMappings": [
-        {
-          "DeviceName": "/dev/xvda",
-          "Ebs": {
-            "DeleteOnTermination": false,
-            "VolumeType": "io1",
-            "VolumeSize": 50,
-            "SnapshotId": "snap-32fb8628",
-            "Iops": 300
-          }
-        }
-      ],
-      "NetworkInterfaces": [
-        {
-          "DeviceIndex": 0,
-          "SubnetId": "subnet-495f8811",
-          "DeleteOnTermination": true,
-          "Groups": [
-            "sg-38353646",
-            "sg-c43437ba"
-          ],
-          "AssociatePublicIpAddress": true
-        }
-      ]
-    },
-    {
-      "ImageId": "ami-27152c5c",
-      "InstanceType": "c4.8xlarge",
-      "KeyName": "aws01",
-      "SpotPrice": "0.9",
-      "BlockDeviceMappings": [
-        {
-          "DeviceName": "/dev/xvda",
-          "Ebs": {
-            "DeleteOnTermination": false,
-            "VolumeType": "io1",
-            "VolumeSize": 50,
-            "SnapshotId": "snap-32fb8628",
-            "Iops": 300
-          }
-        }
-      ],
-      "NetworkInterfaces": [
-        {
-          "DeviceIndex": 0,
-          "SubnetId": "subnet-2af03200",
-          "DeleteOnTermination": true,
-          "Groups": [
-            "sg-38353646",
-            "sg-c43437ba"
-          ],
-          "AssociatePublicIpAddress": true
-        }
-      ]
-    },
-    {
-      "ImageId": "ami-27152c5c",
-      "InstanceType": "c4.8xlarge",
-      "KeyName": "aws01",
-      "SpotPrice": "0.9",
-      "BlockDeviceMappings": [
-        {
-          "DeviceName": "/dev/xvda",
-          "Ebs": {
-            "DeleteOnTermination": false,
-            "VolumeType": "io1",
-            "VolumeSize": 50,
-            "SnapshotId": "snap-32fb8628",
-            "Iops": 300
-          }
-        }
-      ],
-      "NetworkInterfaces": [
-        {
-          "DeviceIndex": 0,
-          "SubnetId": "subnet-cf67fcf2",
           "DeleteOnTermination": true,
           "Groups": [
             "sg-38353646",

--- a/aws_setup/config_p2.8xlarge.json
+++ b/aws_setup/config_p2.8xlarge.json
@@ -16,9 +16,9 @@
         {
           "DeviceName": "/dev/xvda",
           "Ebs": {
-            "DeleteOnTermination": false,
+            "DeleteOnTermination": true,
             "VolumeType": "io1",
-            "VolumeSize": 50,
+            "VolumeSize": 100,
             "SnapshotId": "snap-07a718cb535184f17",
             "Iops": 300
           }

--- a/aws_setup/config_p2.xlarge.json
+++ b/aws_setup/config_p2.xlarge.json
@@ -16,7 +16,7 @@
         {
           "DeviceName": "/dev/xvda",
           "Ebs": {
-            "DeleteOnTermination": false,
+            "DeleteOnTermination": true,
             "VolumeType": "io1",
             "VolumeSize": 100,
             "SnapshotId": "snap-07a718cb535184f17",


### PR DESCRIPTION
Deletes the volumes on termination to not keep any resources around.
Update the c4.8xlarge config